### PR TITLE
feat(ui): Implementar navegação e estrutura de eventos entre views

### DIFF
--- a/CRUDMaker/CRUDMaker.dpr
+++ b/CRUDMaker/CRUDMaker.dpr
@@ -29,7 +29,8 @@ uses
   UViewPrincipal in 'src\view\UViewPrincipal.pas' {Form6},
   UViewLogin in 'src\view\UViewLogin.pas' {Form7},
   UViewVisualizadorRelatorio in 'src\view\UViewVisualizadorRelatorio.pas' {Form8},
-  UGridFlow in 'src\view\UGridFlow.pas' {Form10};
+  UGridFlow in 'src\view\UGridFlow.pas' {Form10},
+  UViewController in 'src\controller\UViewController.pas';
 
 {$R *.res}
 

--- a/CRUDMaker/CRUDMaker.dproj
+++ b/CRUDMaker/CRUDMaker.dproj
@@ -188,6 +188,18 @@
         <DCCReference Include="src\view\UGridFlow.pas">
             <Form>Form10</Form>
         </DCCReference>
+        <DCCReference Include="src\controller\UViewController.pas"/>
+        <None Include="src\controller\explicacaocontroller.txt"/>
+        <None Include="src\controller\__history\UViewController.pas.~10~"/>
+        <None Include="src\controller\__history\UViewController.pas.~11~"/>
+        <None Include="src\controller\__history\UViewController.pas.~12~"/>
+        <None Include="src\controller\__history\UViewController.pas.~13~"/>
+        <None Include="src\controller\__history\UViewController.pas.~14~"/>
+        <None Include="src\controller\__history\UViewController.pas.~5~"/>
+        <None Include="src\controller\__history\UViewController.pas.~6~"/>
+        <None Include="src\controller\__history\UViewController.pas.~7~"/>
+        <None Include="src\controller\__history\UViewController.pas.~8~"/>
+        <None Include="src\controller\__history\UViewController.pas.~9~"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>
@@ -229,6 +241,72 @@
                 <DeployFile LocalName="Win64\Debug\CRUDMaker.rsm" Configuration="Debug" Class="DebugSymbols">
                     <Platform Name="Win64">
                         <RemoteName>CRUDMaker.rsm</RemoteName>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\__history\UViewController.pas.~10~" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\__history\UViewController.pas.~11~" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\__history\UViewController.pas.~12~" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\__history\UViewController.pas.~13~" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\__history\UViewController.pas.~14~" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\__history\UViewController.pas.~5~" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\__history\UViewController.pas.~6~" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\__history\UViewController.pas.~7~" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\__history\UViewController.pas.~8~" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\__history\UViewController.pas.~9~" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="src\controller\explicacaocontroller.txt" Configuration="Debug" Class="ProjectFile">
+                    <Platform Name="Win64">
+                        <RemoteDir>.\</RemoteDir>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>

--- a/CRUDMaker/src/controller/UViewController.pas
+++ b/CRUDMaker/src/controller/UViewController.pas
@@ -1,0 +1,200 @@
+﻿unit UViewController;
+
+interface
+
+uses
+  // Model/DTO units (for passing data)
+  UPlanilhaDTO, URelatorioDTO,
+  // System units
+  System.Classes, System.SysUtils, Vcl.Forms, Vcl.Controls;
+
+type
+  /// <summary>
+  /// Controller responsável por gerenciar a navegação e o ciclo de vida das views da aplicação.
+  /// </summary>
+  TViewController = class
+  private
+    class var FInstance: TViewController;
+    class function GetInstance: TViewController; static;
+  public
+    class property Instance: TViewController read GetInstance;
+
+    // --- Gerenciamento de Views ---
+    /// <summary>
+    /// Mostra a view de Login. Normalmente a primeira view exibida.
+    /// </summary>
+    procedure ShowLoginView(AModal: Boolean = False);
+
+    /// <summary>
+    /// Mostra a view principal da aplicação após o login bem-sucedido.
+    /// </summary>
+    procedure ShowMainView(AUsuarioNome: string);
+
+    /// <summary>
+    /// Mostra o modal de Termos de Uso.
+    /// </summary>
+    /// <returns>True se aceito, False se recusado/cancelado.</returns>
+    function ShowTermsView: Boolean;
+
+    // --- Navegação de Planilha ---
+    /// <summary>
+    /// Abre a view do Editor de Planilha.
+    /// </summary>
+    /// <param name="APlanilha">O DTO da planilha para editar (pode ser nil para nova).</param>
+    procedure ShowEditorPlanilhaView(APlanilha: TPlanilhaDTO = nil);
+
+    // --- Navegação de Relatório ---
+    /// <summary>
+    /// Abre a view do Editor de Relatório.
+    /// </summary>
+    /// <param name="ARelatorio">O DTO do relatório para editar (pode ser nil para novo).</param>
+    /// <param name="APlanilhaBase">Planilha opcional para usar como base.</param>
+    procedure ShowEditorRelatorioView(ARelatorio: TRelatorioDTO = nil; APlanilhaBase: TPlanilhaDTO = nil);
+
+    /// <summary>
+    /// Abre a view do Visualizador de Relatório.
+    /// </summary>
+    /// <param name="ARelatorio">O DTO do relatório para visualizar.</param>
+    procedure ShowVisualizadorRelatorioView(ARelatorio: TRelatorioDTO);
+
+    // --- Views Auxiliares ---
+    /// <summary>
+    /// Abre a view do Gerenciador de Dados.
+    /// </summary>
+    procedure ShowGerenciadorDadosView;
+
+    /// <summary>
+    /// Abre a view de Compartilhamento.
+    /// </summary>
+    procedure ShowCompartilhamentoView;
+
+    // --- Utilitário ---
+    /// <summary>
+    /// Fecha a view principal atual (UViewPrincipal).
+    /// </summary>
+    procedure CloseMainView;
+
+    /// <summary>
+    /// Libera a instância singleton.
+    /// </summary>
+    class procedure FreeInstance;
+  end;
+
+implementation
+
+uses
+  UViewLogin, UViewPrincipal, UViewEditorPlanilha, UViewEditorRelatorio,
+  UViewGerenciadorDados, UViewCompartilhamento, UViewVisualizadorRelatorio,
+  UViewModalTermos;
+
+{ TViewController }
+
+class function TViewController.GetInstance: TViewController;
+begin
+  if not Assigned(FInstance) then
+    FInstance := TViewController.Create;
+  Result := FInstance;
+end;
+
+procedure TViewController.ShowLoginView(AModal: Boolean);
+var
+  LView: TViewLogin;
+begin
+  LView := TViewLogin.Create(nil);
+  try
+    if AModal then
+      LView.ShowModal
+    else
+      LView.Show;
+  finally
+    if AModal then
+      LView.Free;
+  end;
+end;
+
+procedure TViewController.ShowMainView(AUsuarioNome: string);
+var
+  LView: TViewPrincipal;
+begin
+  LView := TViewPrincipal.Create(Application);
+  LView.DefinirNomeUsuario(AUsuarioNome);
+  LView.Show;
+end;
+
+function TViewController.ShowTermsView: Boolean;
+var
+  LView: TViewModalTermos;
+begin
+  Result := False;
+  LView := TViewModalTermos.Create(nil);
+  try
+    Result := (LView.ShowModal = mrOk);
+  finally
+    LView.Free;
+  end;
+end;
+
+procedure TViewController.ShowEditorPlanilhaView(APlanilha: TPlanilhaDTO);
+var
+  LView: TViewEditorPlanilha;
+begin
+  LView := TViewEditorPlanilha.Create(Application);
+  LView.Show;
+end;
+
+procedure TViewController.ShowEditorRelatorioView(ARelatorio: TRelatorioDTO; APlanilhaBase: TPlanilhaDTO);
+var
+  LView: TViewEditorRelatorio;
+begin
+  LView := TViewEditorRelatorio.Create(Application);
+  LView.Show;
+end;
+
+procedure TViewController.ShowVisualizadorRelatorioView(ARelatorio: TRelatorioDTO);
+var
+  LView: TViewVisualizadorRelatorio;
+begin
+  LView := TViewVisualizadorRelatorio.Create(Application, ARelatorio);
+  LView.Show;
+end;
+
+procedure TViewController.ShowGerenciadorDadosView;
+var
+  LView: TViewGerenciadorDados;
+begin
+  LView := TViewGerenciadorDados.Create(Application);
+  LView.Show;
+end;
+
+procedure TViewController.ShowCompartilhamentoView;
+var
+  LView: TViewCompartilhamento;
+begin
+  LView := TViewCompartilhamento.Create(Application);
+  LView.Show;
+end;
+
+procedure TViewController.CloseMainView;
+var
+  I: Integer;
+  LForm: TForm;
+begin
+  for I := 0 to Application.ComponentCount - 1 do
+  begin
+    if Application.Components[I] is TViewPrincipal then
+    begin
+      LForm := TForm(Application.Components[I]);
+      LForm.Close;
+    end;
+  end;
+end;
+
+class procedure TViewController.FreeInstance;
+begin
+  if Assigned(FInstance) then
+  begin
+    FreeAndNil(FInstance);
+  end;
+end;
+
+end.

--- a/CRUDMaker/src/controller/explicacaocontroller.txt
+++ b/CRUDMaker/src/controller/explicacaocontroller.txt
@@ -1,3 +1,0 @@
-Contém as unidades (units) que gerenciam a lógica de negócio e a interação entre a interface de usuário (View) e a camada de dados (Model). 
-Em Delphi, você pode criar uma unit para cada área funcional do seu aplicativo. Por exemplo, U_ControllerUsuario.pas conteria a lógica para manipular dados de usuário.
-

--- a/CRUDMaker/src/view/UGridFlow.dfm
+++ b/CRUDMaker/src/view/UGridFlow.dfm
@@ -12,6 +12,14 @@ object FGridFlow: TFGridFlow
   Font.Style = []
   Position = poScreenCenter
   TextHeight = 15
+  object StatusBar1: TStatusBar
+    Left = 0
+    Top = 478
+    Width = 800
+    Height = 22
+    Panels = <>
+    SimplePanel = True
+  end
   object MainMenu1: TMainMenu
     Left = 24
     Top = 16
@@ -45,13 +53,5 @@ object FGridFlow: TFGridFlow
     object Ajuda1: TMenuItem
       Caption = '&Ajuda'
     end
-  end
-  object StatusBar1: TStatusBar
-    Left = 0
-    Top = 478
-    Width = 800
-    Height = 22
-    Panels = <>
-    SimplePanel = True
   end
 end

--- a/CRUDMaker/src/view/UGridFlow.pas
+++ b/CRUDMaker/src/view/UGridFlow.pas
@@ -1,4 +1,4 @@
-unit UGridFlow;  // Primeira unit criada, por isso tem TF, no T
+unit UGridFlow;
 
 interface
 

--- a/CRUDMaker/src/view/UViewCompartilhamento.dfm
+++ b/CRUDMaker/src/view/UViewCompartilhamento.dfm
@@ -12,24 +12,24 @@ object ViewCompartilhamento: TViewCompartilhamento
   Font.Style = []
   Position = poScreenCenter
   TextHeight = 15
-  object PageControlCompartilhar: TPageControl
+  object ControleAbasCompartilhar: TPageControl
     Left = 0
     Top = 0
     Width = 800
     Height = 478
-    ActivePage = TabSheetCompPlanilhas
+    ActivePage = AbaCompPlanilhas
     Align = alClient
     TabOrder = 0
-    object TabSheetCompPlanilhas: TTabSheet
+    object AbaCompPlanilhas: TTabSheet
       Caption = 'Sele'#231#227'o de Planilha'
-      object PanelCompPlanTop: TPanel
+      object PainelCompPlanTopo: TPanel
         Left = 0
         Top = 0
         Width = 792
         Height = 40
         Align = alTop
         TabOrder = 0
-        object CheckBoxSelecionarTodasPlan: TCheckBox
+        object CaixaSelecaoTodasPlan: TCheckBox
           Left = 10
           Top = 10
           Width = 150
@@ -38,7 +38,7 @@ object ViewCompartilhamento: TViewCompartilhamento
           TabOrder = 0
         end
       end
-      object ListBoxCompPlanilhas: TListBox
+      object ListaCompPlanilhas: TListBox
         Left = 0
         Top = 40
         Width = 792
@@ -48,14 +48,14 @@ object ViewCompartilhamento: TViewCompartilhamento
         MultiSelect = True
         TabOrder = 1
       end
-      object PanelCompPlanBotoes: TPanel
+      object PainelCompPlanBotoes: TPanel
         Left = 0
         Top = 418
         Width = 792
         Height = 30
         Align = alBottom
         TabOrder = 2
-        object ButtonExportarPlanilhas: TButton
+        object BotaoExportarPlanilhas: TButton
           Left = 10
           Top = 2
           Width = 150
@@ -65,17 +65,17 @@ object ViewCompartilhamento: TViewCompartilhamento
         end
       end
     end
-    object TabSheetCompRelatorios: TTabSheet
+    object AbaCompRelatorios: TTabSheet
       Caption = 'Sele'#231#227'o de Relat'#243'rio'
       ImageIndex = 1
-      object PanelCompRelTop: TPanel
+      object PainelCompRelTopo: TPanel
         Left = 0
         Top = 0
         Width = 792
         Height = 40
         Align = alTop
         TabOrder = 0
-        object CheckBoxSelecionarTodosRel: TCheckBox
+        object CaixaSelecaoTodosRel: TCheckBox
           Left = 10
           Top = 10
           Width = 150
@@ -84,24 +84,25 @@ object ViewCompartilhamento: TViewCompartilhamento
           TabOrder = 0
         end
       end
-      object ListBoxCompRelatorios: TListBox
+      object ListaCompRelatorios: TListBox
         Left = 0
         Top = 40
         Width = 792
-        Height = 378
+        Height = 367
         Align = alClient
         ItemHeight = 15
         MultiSelect = True
         TabOrder = 1
       end
-      object PanelCompRelBotoes: TPanel
+      object PainelCompRelBotoes: TPanel
         Left = 0
         Top = 418
         Width = 792
         Height = 30
         Align = alBottom
         TabOrder = 2
-        object ButtonExportarRelatorios: TButton
+        ExplicitTop = 407
+        object BotaoExportarRelatorios: TButton
           Left = 10
           Top = 2
           Width = 150
@@ -111,17 +112,17 @@ object ViewCompartilhamento: TViewCompartilhamento
         end
       end
     end
-    object TabSheetCompAssociacoes: TTabSheet
+    object AbaCompAssociacoes: TTabSheet
       Caption = 'Planilhas com Relat'#243'rios'
       ImageIndex = 2
-      object PanelCompAssocTop: TPanel
+      object PainelCompAssocTopo: TPanel
         Left = 0
         Top = 0
         Width = 792
         Height = 40
         Align = alTop
         TabOrder = 0
-        object CheckBoxSelecionarTodasAssoc: TCheckBox
+        object CaixaSelecaoTodasAssoc: TCheckBox
           Left = 10
           Top = 10
           Width = 150
@@ -130,24 +131,25 @@ object ViewCompartilhamento: TViewCompartilhamento
           TabOrder = 0
         end
       end
-      object ListBoxCompAssociacoes: TListBox
+      object ListaCompAssociacoes: TListBox
         Left = 0
         Top = 40
         Width = 792
-        Height = 378
+        Height = 367
         Align = alClient
         ItemHeight = 15
         MultiSelect = True
         TabOrder = 1
       end
-      object PanelCompAssocBotoes: TPanel
+      object PainelCompAssocBotoes: TPanel
         Left = 0
         Top = 418
         Width = 792
         Height = 30
         Align = alBottom
         TabOrder = 2
-        object ButtonExportarAssociacoes: TButton
+        ExplicitTop = 407
+        object BotaoExportarAssociacoes: TButton
           Left = 10
           Top = 2
           Width = 150
@@ -158,14 +160,14 @@ object ViewCompartilhamento: TViewCompartilhamento
       end
     end
   end
-  object PanelCompartilharBottom: TPanel
+  object PainelCompartilharRodape: TPanel
     Left = 0
     Top = 478
     Width = 800
     Height = 22
     Align = alBottom
     TabOrder = 1
-    object StatusBarCompartilhar: TStatusBar
+    object BarraStatusCompartilhar: TStatusBar
       Left = 1
       Top = 1
       Width = 798

--- a/CRUDMaker/src/view/UViewCompartilhamento.pas
+++ b/CRUDMaker/src/view/UViewCompartilhamento.pas
@@ -1,4 +1,4 @@
-unit UViewCompartilhamento;
+﻿unit UViewCompartilhamento;
 
 interface
 
@@ -8,31 +8,32 @@ uses
 
 type
   TViewCompartilhamento = class(TForm)
-    PageControlCompartilhar: TPageControl;
-    TabSheetCompPlanilhas: TTabSheet;
-    PanelCompPlanTop: TPanel;
-    CheckBoxSelecionarTodasPlan: TCheckBox;
-    ListBoxCompPlanilhas: TListBox;
-    PanelCompPlanBotoes: TPanel;
-    ButtonExportarPlanilhas: TButton;
-    TabSheetCompRelatorios: TTabSheet;
-    PanelCompRelTop: TPanel;
-    CheckBoxSelecionarTodosRel: TCheckBox;
-    ListBoxCompRelatorios: TListBox;
-    PanelCompRelBotoes: TPanel;
-    ButtonExportarRelatorios: TButton;
-    TabSheetCompAssociacoes: TTabSheet;
-    PanelCompAssocTop: TPanel;
-    CheckBoxSelecionarTodasAssoc: TCheckBox;
-    ListBoxCompAssociacoes: TListBox;
-    PanelCompAssocBotoes: TPanel;
-    ButtonExportarAssociacoes: TButton;
-    PanelCompartilharBottom: TPanel;
-    StatusBarCompartilhar: TStatusBar;
+    ControleAbasCompartilhar: TPageControl;
+    AbaCompPlanilhas: TTabSheet;
+    PainelCompPlanTopo: TPanel;
+    CaixaSelecaoTodasPlan: TCheckBox;
+    ListaCompPlanilhas: TListBox;
+    PainelCompPlanBotoes: TPanel;
+    BotaoExportarPlanilhas: TButton;
+    AbaCompRelatorios: TTabSheet;
+    PainelCompRelTopo: TPanel;
+    CaixaSelecaoTodosRel: TCheckBox;
+    ListaCompRelatorios: TListBox;
+    PainelCompRelBotoes: TPanel;
+    BotaoExportarRelatorios: TButton;
+    AbaCompAssociacoes: TTabSheet;
+    PainelCompAssocTopo: TPanel;
+    CaixaSelecaoTodasAssoc: TCheckBox;
+    ListaCompAssociacoes: TListBox;
+    PainelCompAssocBotoes: TPanel;
+    BotaoExportarAssociacoes: TButton;
+    PainelCompartilharRodape: TPanel;
+    BarraStatusCompartilhar: TStatusBar;
+    procedure BotaoExportarPlanilhasClick(Sender: TObject);
+    procedure BotaoExportarRelatoriosClick(Sender: TObject);
+    procedure BotaoExportarAssociacoesClick(Sender: TObject);
   private
-    { Private declarations }
   public
-    { Public declarations }
   end;
 
 var
@@ -41,5 +42,20 @@ var
 implementation
 
 {$R *.dfm}
+
+procedure TViewCompartilhamento.BotaoExportarPlanilhasClick(Sender: TObject);
+begin
+  ShowMessage('Funcionalidade de exportar planilhas acionada.');
+end;
+
+procedure TViewCompartilhamento.BotaoExportarRelatoriosClick(Sender: TObject);
+begin
+  ShowMessage('Funcionalidade de exportar relatórios acionada.');
+end;
+
+procedure TViewCompartilhamento.BotaoExportarAssociacoesClick(Sender: TObject);
+begin
+  ShowMessage('Funcionalidade de exportar associações acionada.');
+end;
 
 end.

--- a/CRUDMaker/src/view/UViewEditorPlanilha.dfm
+++ b/CRUDMaker/src/view/UViewEditorPlanilha.dfm
@@ -12,37 +12,45 @@ object ViewEditorPlanilha: TViewEditorPlanilha
   Font.Style = []
   Position = poScreenCenter
   TextHeight = 15
-  object PanelEditorTop: TPanel
+  object PainelEditorTopo: TPanel
     Left = 0
     Top = 0
     Width = 800
     Height = 50
     Align = alTop
     TabOrder = 0
-    object LabelTituloPlanilha: TLabel
+    object RotuloTituloPlanilha: TLabel
       Left = 10
       Top = 15
-      Width = 30
+      Width = 34
       Height = 15
       Caption = 'T'#237'tulo:'
     end
-    object EditTituloPlanilha: TEdit
+    object EditarTituloPlanilha: TEdit
       Left = 50
       Top = 12
       Width = 300
       Height = 23
       TabOrder = 0
     end
-    object ButtonSalvarPlanilha: TButton
-      Left = 690
+    object BotaoSalvarPlanilha: TButton
+      Left = 580
       Top = 10
       Width = 100
       Height = 30
       Caption = 'Salvar'
       TabOrder = 1
     end
+    object BotaoCancelarPlanilha: TButton
+      Left = 690
+      Top = 10
+      Width = 100
+      Height = 30
+      Caption = 'Cancelar'
+      TabOrder = 2
+    end
   end
-  object StringGridEditor: TStringGrid
+  object GradeEditor: TStringGrid
     Left = 0
     Top = 50
     Width = 800
@@ -51,16 +59,17 @@ object ViewEditorPlanilha: TViewEditorPlanilha
     ColCount = 10
     FixedCols = 0
     RowCount = 20
+    Options = [goFixedVertLine, goFixedHorzLine, goVertLine, goHorzLine, goRangeSelect, goDrawFocusSelected, goEditing]
     TabOrder = 1
   end
-  object PanelEditorBottom: TPanel
+  object PainelEditorRodape: TPanel
     Left = 0
     Top = 478
     Width = 800
     Height = 22
     Align = alBottom
     TabOrder = 2
-    object StatusBarEditor: TStatusBar
+    object BarraStatusEditor: TStatusBar
       Left = 1
       Top = 1
       Width = 798

--- a/CRUDMaker/src/view/UViewEditorPlanilha.pas
+++ b/CRUDMaker/src/view/UViewEditorPlanilha.pas
@@ -1,24 +1,41 @@
-unit UViewEditorPlanilha;
+﻿unit UViewEditorPlanilha;
 
 interface
 
 uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
-  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.Grids, Vcl.StdCtrls, Vcl.ExtCtrls, Vcl.ComCtrls;
+  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.Grids, Vcl.StdCtrls, Vcl.ExtCtrls, Vcl.ComCtrls,
+  UPlanilhaDTO;
 
 type
+  TSolicitarSalvarPlanilhaEvent = procedure(const APlanilha: TPlanilhaDTO) of object;
+  TSolicitarCancelarEdicaoEvent = procedure of object;
+
   TViewEditorPlanilha = class(TForm)
-    PanelEditorTop: TPanel;
-    LabelTituloPlanilha: TLabel;
-    EditTituloPlanilha: TEdit;
-    ButtonSalvarPlanilha: TButton;
-    StringGridEditor: TStringGrid;
-    PanelEditorBottom: TPanel;
-    StatusBarEditor: TStatusBar;
+    PainelEditorTopo: TPanel;
+    RotuloTituloPlanilha: TLabel;
+    EditarTituloPlanilha: TEdit;
+    BotaoSalvarPlanilha: TButton;
+    BotaoCancelarPlanilha: TButton;
+    GradeEditor: TStringGrid;
+    PainelEditorRodape: TPanel;
+    BarraStatusEditor: TStatusBar;
+    procedure BotaoSalvarPlanilhaClick(Sender: TObject);
+    procedure BotaoCancelarPlanilhaClick(Sender: TObject);
+    procedure FormCreate(Sender: TObject);
   private
-    { Private declarations }
+    FPlanilha: TPlanilhaDTO;
+    FSendoEditada: Boolean;
+    FOnSolicitarSalvar: TSolicitarSalvarPlanilhaEvent;
+    FOnSolicitarCancelar: TSolicitarCancelarEdicaoEvent;
+    procedure CarregarPlanilhaNaInterface;
+    procedure AtualizarPlanilhaDoInterface;
   public
-    { Public declarations }
+    constructor Create(AOwner: TComponent); reintroduce; overload;
+    constructor Create(AOwner: TComponent; APlanilha: TPlanilhaDTO); reintroduce; overload;
+    destructor Destroy; override;
+    property OnSolicitarSalvar: TSolicitarSalvarPlanilhaEvent read FOnSolicitarSalvar write FOnSolicitarSalvar;
+    property OnSolicitarCancelar: TSolicitarCancelarEdicaoEvent read FOnSolicitarCancelar write FOnSolicitarCancelar;
   end;
 
 var
@@ -27,5 +44,61 @@ var
 implementation
 
 {$R *.dfm}
+
+constructor TViewEditorPlanilha.Create(AOwner: TComponent);
+begin
+  Create(AOwner, nil);
+end;
+
+constructor TViewEditorPlanilha.Create(AOwner: TComponent; APlanilha: TPlanilhaDTO);
+begin
+  inherited Create(AOwner);
+  FPlanilha := APlanilha;
+  FSendoEditada := Assigned(APlanilha);
+end;
+
+destructor TViewEditorPlanilha.Destroy;
+begin
+  if not FSendoEditada and Assigned(FPlanilha) then
+    FPlanilha.Free;
+  inherited;
+end;
+
+procedure TViewEditorPlanilha.FormCreate(Sender: TObject);
+begin
+  if Assigned(FPlanilha) then
+  begin
+    CarregarPlanilhaNaInterface;
+  end;
+end;
+
+procedure TViewEditorPlanilha.CarregarPlanilhaNaInterface;
+begin
+  if Assigned(FPlanilha) then
+  begin
+    EditarTituloPlanilha.Text := FPlanilha.Titulo;
+  end;
+end;
+
+procedure TViewEditorPlanilha.AtualizarPlanilhaDoInterface;
+begin
+  if not Assigned(FPlanilha) then
+    FPlanilha := TPlanilhaDTO.Create;
+  FPlanilha.Titulo := EditarTituloPlanilha.Text;
+end;
+
+procedure TViewEditorPlanilha.BotaoSalvarPlanilhaClick(Sender: TObject);
+begin
+  AtualizarPlanilhaDoInterface;
+  if Assigned(FOnSolicitarSalvar) then
+    FOnSolicitarSalvar(FPlanilha);
+end;
+
+procedure TViewEditorPlanilha.BotaoCancelarPlanilhaClick(Sender: TObject);
+begin
+  if Assigned(FOnSolicitarCancelar) then
+    FOnSolicitarCancelar;
+  Self.Close;
+end;
 
 end.

--- a/CRUDMaker/src/view/UViewEditorRelatorio.dfm
+++ b/CRUDMaker/src/view/UViewEditorRelatorio.dfm
@@ -12,28 +12,28 @@ object ViewEditorRelatorio: TViewEditorRelatorio
   Font.Style = []
   Position = poScreenCenter
   TextHeight = 15
-  object PanelRelatorioTop: TPanel
+  object PainelRelatorioTopo: TPanel
     Left = 0
     Top = 0
     Width = 800
     Height = 100
     Align = alTop
     TabOrder = 0
-    object LabelTituloRelatorio: TLabel
+    object RotuloTituloRelatorio: TLabel
       Left = 10
       Top = 15
-      Width = 30
+      Width = 34
       Height = 15
       Caption = 'T'#237'tulo:'
     end
-    object LabelTipoRelatorio: TLabel
+    object RotuloTipoRelatorio: TLabel
       Left = 10
       Top = 55
-      Width = 28
+      Width = 27
       Height = 15
       Caption = 'Tipo:'
     end
-    object EditTituloRelatorio: TEdit
+    object EditarTituloRelatorio: TEdit
       Left = 50
       Top = 12
       Width = 300
@@ -46,22 +46,23 @@ object ViewEditorRelatorio: TViewEditorRelatorio
       Width = 200
       Height = 23
       Style = csDropDownList
-      ItemIndex = 0
       TabOrder = 1
-      Text = 'Ordenador'
-      Items.Strings = (
-        'Ordenador'
-        'Anal'#237'tico'
-        'Gr'#225'fico/Visual'
-        'Riscos/Alertas')
     end
-    object ButtonSalvarRelatorio: TButton
-      Left = 690
+    object BotaoSalvarRelatorio: TButton
+      Left = 580
       Top = 35
       Width = 100
       Height = 30
       Caption = 'Salvar'
       TabOrder = 2
+    end
+    object BotaoCancelarRelatorio: TButton
+      Left = 690
+      Top = 35
+      Width = 100
+      Height = 30
+      Caption = 'Cancelar'
+      TabOrder = 3
     end
   end
   object MemoConfiguracaoRelatorio: TMemo
@@ -75,14 +76,14 @@ object ViewEditorRelatorio: TViewEditorRelatorio
     ScrollBars = ssVertical
     TabOrder = 1
   end
-  object PanelRelatorioBottom: TPanel
+  object PainelRelatorioRodape: TPanel
     Left = 0
     Top = 478
     Width = 800
     Height = 22
     Align = alBottom
     TabOrder = 2
-    object StatusBarRelatorio: TStatusBar
+    object BarraStatusRelatorio: TStatusBar
       Left = 1
       Top = 1
       Width = 798

--- a/CRUDMaker/src/view/UViewEditorRelatorio.pas
+++ b/CRUDMaker/src/view/UViewEditorRelatorio.pas
@@ -1,26 +1,43 @@
-unit UViewEditorRelatorio;
+﻿unit UViewEditorRelatorio;
 
 interface
 
 uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
-  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, Vcl.ExtCtrls, Vcl.ComCtrls;
+  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, Vcl.ExtCtrls, Vcl.ComCtrls,
+  URelatorioDTO, UPlanilhaDTO;
 
 type
+  TSolicitarSalvarRelatorioEvent = procedure(const ARelatorio: TRelatorioDTO) of object;
+  TSolicitarCancelarEdicaoRelatorioEvent = procedure of object;
+
   TViewEditorRelatorio = class(TForm)
-    PanelRelatorioTop: TPanel;
-    LabelTituloRelatorio: TLabel;
-    LabelTipoRelatorio: TLabel;
-    EditTituloRelatorio: TEdit;
+    PainelRelatorioTopo: TPanel;
+    RotuloTituloRelatorio: TLabel;
+    RotuloTipoRelatorio: TLabel;
+    EditarTituloRelatorio: TEdit;
     ComboBoxTipoRelatorio: TComboBox;
-    ButtonSalvarRelatorio: TButton;
+    BotaoSalvarRelatorio: TButton;
+    BotaoCancelarRelatorio: TButton;
     MemoConfiguracaoRelatorio: TMemo;
-    PanelRelatorioBottom: TPanel;
-    StatusBarRelatorio: TStatusBar;
+    PainelRelatorioRodape: TPanel;
+    BarraStatusRelatorio: TStatusBar;
+    procedure BotaoSalvarRelatorioClick(Sender: TObject);
+    procedure BotaoCancelarRelatorioClick(Sender: TObject);
+    procedure FormCreate(Sender: TObject);
   private
-    { Private declarations }
+    FRelatorio: TRelatorioDTO;
+    FSendoEditada: Boolean;
+    FOnSolicitarSalvar: TSolicitarSalvarRelatorioEvent;
+    FOnSolicitarCancelar: TSolicitarCancelarEdicaoRelatorioEvent;
+    procedure CarregarRelatorioNaInterface;
+    procedure AtualizarRelatorioDoInterface;
   public
-    { Public declarations }
+    constructor Create(AOwner: TComponent); reintroduce; overload;
+    constructor Create(AOwner: TComponent; ARelatorio: TRelatorioDTO); reintroduce; overload;
+    destructor Destroy; override;
+    property OnSolicitarSalvar: TSolicitarSalvarRelatorioEvent read FOnSolicitarSalvar write FOnSolicitarSalvar;
+    property OnSolicitarCancelar: TSolicitarCancelarEdicaoRelatorioEvent read FOnSolicitarCancelar write FOnSolicitarCancelar;
   end;
 
 var
@@ -29,5 +46,63 @@ var
 implementation
 
 {$R *.dfm}
+
+constructor TViewEditorRelatorio.Create(AOwner: TComponent);
+begin
+  Create(AOwner, nil);
+end;
+
+constructor TViewEditorRelatorio.Create(AOwner: TComponent; ARelatorio: TRelatorioDTO);
+begin
+  inherited Create(AOwner);
+  FRelatorio := ARelatorio;
+  FSendoEditada := Assigned(ARelatorio);
+end;
+
+destructor TViewEditorRelatorio.Destroy;
+begin
+  if not FSendoEditada and Assigned(FRelatorio) then
+    FRelatorio.Free;
+  inherited;
+end;
+
+procedure TViewEditorRelatorio.FormCreate(Sender: TObject);
+begin
+  ComboBoxTipoRelatorio.Items.CommaText := 'Ordenador,Analítico,Gráfico/Visual,Riscos/Alertas';
+  ComboBoxTipoRelatorio.ItemIndex := 0;
+  if Assigned(FRelatorio) then
+  begin
+    CarregarRelatorioNaInterface;
+  end;
+end;
+
+procedure TViewEditorRelatorio.CarregarRelatorioNaInterface;
+begin
+  if Assigned(FRelatorio) then
+  begin
+    EditarTituloRelatorio.Text := FRelatorio.Titulo;
+  end;
+end;
+
+procedure TViewEditorRelatorio.AtualizarRelatorioDoInterface;
+begin
+  if not Assigned(FRelatorio) then
+    FRelatorio := TRelatorioDTO.Create;
+  FRelatorio.Titulo := EditarTituloRelatorio.Text;
+end;
+
+procedure TViewEditorRelatorio.BotaoSalvarRelatorioClick(Sender: TObject);
+begin
+  AtualizarRelatorioDoInterface;
+  if Assigned(FOnSolicitarSalvar) then
+    FOnSolicitarSalvar(FRelatorio);
+end;
+
+procedure TViewEditorRelatorio.BotaoCancelarRelatorioClick(Sender: TObject);
+begin
+  if Assigned(FOnSolicitarCancelar) then
+    FOnSolicitarCancelar;
+  Self.Close;
+end;
 
 end.

--- a/CRUDMaker/src/view/UViewGerenciadorDados.dfm
+++ b/CRUDMaker/src/view/UViewGerenciadorDados.dfm
@@ -12,24 +12,24 @@ object ViewGerenciadorDados: TViewGerenciadorDados
   Font.Style = []
   Position = poScreenCenter
   TextHeight = 15
-  object PageControlGerenciador: TPageControl
+  object ControleAbasGerenciador: TPageControl
     Left = 0
     Top = 0
     Width = 800
     Height = 478
-    ActivePage = TabSheetGerPlanilhas
+    ActivePage = AbaGerPlanilhas
     Align = alClient
     TabOrder = 0
-    object TabSheetGerPlanilhas: TTabSheet
+    object AbaGerPlanilhas: TTabSheet
       Caption = 'Planilhas'
-      object PanelGerPlanilhasTop: TPanel
+      object PainelGerPlanilhasTopo: TPanel
         Left = 0
         Top = 0
         Width = 792
         Height = 40
         Align = alTop
         TabOrder = 0
-        object ButtonNovaPlanilha: TButton
+        object BotaoNovaPlanilha: TButton
           Left = 10
           Top = 5
           Width = 120
@@ -38,7 +38,7 @@ object ViewGerenciadorDados: TViewGerenciadorDados
           TabOrder = 0
         end
       end
-      object DBGridGerPlanilhas: TDBGrid
+      object GradeGerPlanilhas: TDBGrid
         Left = 0
         Top = 40
         Width = 792
@@ -52,17 +52,17 @@ object ViewGerenciadorDados: TViewGerenciadorDados
         TitleFont.Style = []
       end
     end
-    object TabSheetGerRelatorios: TTabSheet
+    object AbaGerRelatorios: TTabSheet
       Caption = 'Relat'#243'rios'
       ImageIndex = 1
-      object PanelGerRelatoriosTop: TPanel
+      object PainelGerRelatoriosTopo: TPanel
         Left = 0
         Top = 0
         Width = 792
         Height = 40
         Align = alTop
         TabOrder = 0
-        object ButtonNovoRelatorio: TButton
+        object BotaoNovoRelatorio: TButton
           Left = 10
           Top = 5
           Width = 120
@@ -71,11 +71,11 @@ object ViewGerenciadorDados: TViewGerenciadorDados
           TabOrder = 0
         end
       end
-      object DBGridGerRelatorios: TDBGrid
+      object GradeGerRelatorios: TDBGrid
         Left = 0
         Top = 40
         Width = 792
-        Height = 408
+        Height = 397
         Align = alClient
         TabOrder = 1
         TitleFont.Charset = DEFAULT_CHARSET
@@ -85,17 +85,17 @@ object ViewGerenciadorDados: TViewGerenciadorDados
         TitleFont.Style = []
       end
     end
-    object TabSheetGerAssociacoes: TTabSheet
+    object AbaGerAssociacoes: TTabSheet
       Caption = 'Associa'#231#245'es'
       ImageIndex = 2
-      object PanelGerAssociacoesTop: TPanel
+      object PainelGerAssociacoesTopo: TPanel
         Left = 0
         Top = 0
         Width = 792
         Height = 40
         Align = alTop
         TabOrder = 0
-        object ButtonNovaAssociacao: TButton
+        object BotaoNovaAssociacao: TButton
           Left = 10
           Top = 5
           Width = 150
@@ -104,11 +104,11 @@ object ViewGerenciadorDados: TViewGerenciadorDados
           TabOrder = 0
         end
       end
-      object DBGridGerAssociacoes: TDBGrid
+      object GradeGerAssociacoes: TDBGrid
         Left = 0
         Top = 40
         Width = 792
-        Height = 408
+        Height = 397
         Align = alClient
         TabOrder = 1
         TitleFont.Charset = DEFAULT_CHARSET
@@ -119,14 +119,14 @@ object ViewGerenciadorDados: TViewGerenciadorDados
       end
     end
   end
-  object PanelGerenciadorBottom: TPanel
+  object PainelGerenciadorRodape: TPanel
     Left = 0
     Top = 478
     Width = 800
     Height = 22
     Align = alBottom
     TabOrder = 1
-    object StatusBarGerenciador: TStatusBar
+    object BarraStatusGerenciador: TStatusBar
       Left = 1
       Top = 1
       Width = 798

--- a/CRUDMaker/src/view/UViewGerenciadorDados.pas
+++ b/CRUDMaker/src/view/UViewGerenciadorDados.pas
@@ -1,4 +1,4 @@
-unit UViewGerenciadorDados;
+﻿unit UViewGerenciadorDados;
 
 interface
 
@@ -9,25 +9,26 @@ uses
 
 type
   TViewGerenciadorDados = class(TForm)
-    PageControlGerenciador: TPageControl;
-    TabSheetGerPlanilhas: TTabSheet;
-    PanelGerPlanilhasTop: TPanel;
-    ButtonNovaPlanilha: TButton;
-    DBGridGerPlanilhas: TDBGrid;
-    TabSheetGerRelatorios: TTabSheet;
-    PanelGerRelatoriosTop: TPanel;
-    ButtonNovoRelatorio: TButton;
-    DBGridGerRelatorios: TDBGrid;
-    TabSheetGerAssociacoes: TTabSheet;
-    PanelGerAssociacoesTop: TPanel;
-    ButtonNovaAssociacao: TButton;
-    DBGridGerAssociacoes: TDBGrid;
-    PanelGerenciadorBottom: TPanel;
-    StatusBarGerenciador: TStatusBar;
+    ControleAbasGerenciador: TPageControl;
+    AbaGerPlanilhas: TTabSheet;
+    PainelGerPlanilhasTopo: TPanel;
+    BotaoNovaPlanilha: TButton;
+    GradeGerPlanilhas: TDBGrid;
+    AbaGerRelatorios: TTabSheet;
+    PainelGerRelatoriosTopo: TPanel;
+    BotaoNovoRelatorio: TButton;
+    GradeGerRelatorios: TDBGrid;
+    AbaGerAssociacoes: TTabSheet;
+    PainelGerAssociacoesTopo: TPanel;
+    BotaoNovaAssociacao: TButton;
+    GradeGerAssociacoes: TDBGrid;
+    PainelGerenciadorRodape: TPanel;
+    BarraStatusGerenciador: TStatusBar;
+    procedure BotaoNovaPlanilhaClick(Sender: TObject);
+    procedure BotaoNovoRelatorioClick(Sender: TObject);
+    procedure BotaoNovaAssociacaoClick(Sender: TObject);
   private
-    { Private declarations }
   public
-    { Public declarations }
   end;
 
 var
@@ -36,5 +37,20 @@ var
 implementation
 
 {$R *.dfm}
+
+procedure TViewGerenciadorDados.BotaoNovaPlanilhaClick(Sender: TObject);
+begin
+  ShowMessage('Funcionalidade de criar nova planilha acionada. O controller deve tratar isso.');
+end;
+
+procedure TViewGerenciadorDados.BotaoNovoRelatorioClick(Sender: TObject);
+begin
+  ShowMessage('Funcionalidade de criar novo relatório acionada. O controller deve tratar isso.');
+end;
+
+procedure TViewGerenciadorDados.BotaoNovaAssociacaoClick(Sender: TObject);
+begin
+  ShowMessage('Funcionalidade de criar nova associação acionada. O controller deve tratar isso.');
+end;
 
 end.

--- a/CRUDMaker/src/view/UViewLogin.dfm
+++ b/CRUDMaker/src/view/UViewLogin.dfm
@@ -3,7 +3,7 @@ object ViewLogin: TViewLogin
   Top = 0
   BorderStyle = bsDialog
   Caption = 'Login - GridFlow'
-  ClientHeight = 250
+  ClientHeight = 220
   ClientWidth = 400
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
@@ -13,71 +13,84 @@ object ViewLogin: TViewLogin
   Font.Style = []
   Position = poScreenCenter
   TextHeight = 15
-  object PanelLogin: TPanel
+  object PainelLogin: TPanel
     Left = 0
     Top = 0
     Width = 400
-    Height = 250
+    Height = 220
     Align = alClient
     TabOrder = 0
-    ExplicitLeft = 8
-    ExplicitTop = 8
-    ExplicitWidth = 385
-    ExplicitHeight = 233
-    object LabelUsuario: TLabel
-      Left = 50
-      Top = 60
-      Width = 42
+    object RotuloUsuario: TLabel
+      Left = 24
+      Top = 24
+      Width = 43
       Height = 15
       Caption = 'Usu'#225'rio:'
     end
-    object LabelSenha: TLabel
-      Left = 50
-      Top = 110
-      Width = 37
+    object RotuloSenha: TLabel
+      Left = 24
+      Top = 64
+      Width = 35
       Height = 15
       Caption = 'Senha:'
     end
-    object EditUsuario: TEdit
-      Left = 50
-      Top = 80
-      Width = 300
+    object GrupoBoxModo: TGroupBox
+      Left = 24
+      Top = 104
+      Width = 353
+      Height = 57
+      Caption = ' Modo de Opera'#231#227'o '
+      TabOrder = 4
+      object RadioButtonPublico: TRadioButton
+        Left = 16
+        Top = 24
+        Width = 113
+        Height = 17
+        Caption = 'P'#250'blico (Servidor)'
+        TabOrder = 0
+      end
+      object RadioButtonPrivado: TRadioButton
+        Left = 184
+        Top = 24
+        Width = 113
+        Height = 17
+        Caption = 'Privado (Local)'
+        Checked = True
+        TabOrder = 1
+        TabStop = True
+      end
+    end
+    object EditarUsuario: TEdit
+      Left = 88
+      Top = 21
+      Width = 289
       Height = 23
       TabOrder = 0
     end
-    object EditSenha: TEdit
-      Left = 50
-      Top = 130
-      Width = 300
+    object EditarSenha: TEdit
+      Left = 88
+      Top = 61
+      Width = 289
       Height = 23
       PasswordChar = '*'
       TabOrder = 1
     end
-    object ButtonLogin: TButton
-      Left = 150
-      Top = 180
-      Width = 100
-      Height = 30
+    object BotaoLogin: TButton
+      Left = 120
+      Top = 176
+      Width = 75
+      Height = 25
       Caption = 'Entrar'
+      Default = True
       TabOrder = 2
     end
-    object RadioButtonPublico: TRadioButton
-      Left = 50
-      Top = 20
-      Width = 113
-      Height = 17
-      Caption = 'Modo P'#250'blico'
-      Checked = True
+    object BotaoCancelar: TButton
+      Left = 208
+      Top = 176
+      Width = 75
+      Height = 25
+      Caption = 'Cancelar'
       TabOrder = 3
-      TabStop = True
-    end
-    object RadioButtonPrivado: TRadioButton
-      Left = 180
-      Top = 20
-      Width = 113
-      Height = 17
-      Caption = 'Modo Privado'
-      TabOrder = 4
     end
   end
 end

--- a/CRUDMaker/src/view/UViewLogin.pas
+++ b/CRUDMaker/src/view/UViewLogin.pas
@@ -1,4 +1,4 @@
-unit UViewLogin;
+﻿unit UViewLogin;
 
 interface
 
@@ -7,19 +7,29 @@ uses
   Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, Vcl.ExtCtrls;
 
 type
+  TOnLoginEvent = procedure(const AUsuario, ASenha: string; AModoPublico: Boolean) of object;
+  TOnCancelarLoginEvent = procedure of object;
+
   TViewLogin = class(TForm)
-    PanelLogin: TPanel;
-    LabelUsuario: TLabel;
-    LabelSenha: TLabel;
-    EditUsuario: TEdit;
-    EditSenha: TEdit;
-    ButtonLogin: TButton;
+    PainelLogin: TPanel;
+    RotuloUsuario: TLabel;
+    RotuloSenha: TLabel;
+    EditarUsuario: TEdit;
+    EditarSenha: TEdit;
+    BotaoLogin: TButton;
+    BotaoCancelar: TButton;
+    GrupoBoxModo: TGroupBox;
     RadioButtonPublico: TRadioButton;
     RadioButtonPrivado: TRadioButton;
+    procedure BotaoLoginClick(Sender: TObject);
+    procedure BotaoCancelarClick(Sender: TObject);
+    procedure FormCreate(Sender: TObject);
   private
-    { Private declarations }
+    FOnLogin: TOnLoginEvent;
+    FOnCancelarLogin: TOnCancelarLoginEvent;
   public
-    { Public declarations }
+    property OnLogin: TOnLoginEvent read FOnLogin write FOnLogin;
+    property OnCancelarLogin: TOnCancelarLoginEvent read FOnCancelarLogin write FOnCancelarLogin;
   end;
 
 var
@@ -28,5 +38,23 @@ var
 implementation
 
 {$R *.dfm}
+
+procedure TViewLogin.FormCreate(Sender: TObject);
+begin
+  RadioButtonPrivado.Checked := True;
+end;
+
+procedure TViewLogin.BotaoLoginClick(Sender: TObject);
+begin
+  if Assigned(FOnLogin) then
+    FOnLogin(EditarUsuario.Text, EditarSenha.Text, RadioButtonPublico.Checked);
+end;
+
+procedure TViewLogin.BotaoCancelarClick(Sender: TObject);
+begin
+  if Assigned(FOnCancelarLogin) then
+    FOnCancelarLogin;
+  Self.Close;
+end;
 
 end.

--- a/CRUDMaker/src/view/UViewModalTermos.dfm
+++ b/CRUDMaker/src/view/UViewModalTermos.dfm
@@ -12,6 +12,7 @@ object ViewModalTermos: TViewModalTermos
   Font.Name = 'Segoe UI'
   Font.Style = []
   Position = poScreenCenter
+  OnCreate = FormCreate
   TextHeight = 15
   object MemoTermos: TMemo
     Left = 0
@@ -19,26 +20,18 @@ object ViewModalTermos: TViewModalTermos
     Width = 600
     Height = 350
     Align = alTop
-    Lines.Strings = (
-      'TERMO DE RESPONSABILIDADE'
-      ''
-      'Ao utilizar este sistema em modo p'#250'blico, voc'#234' concorda com:'
-      ''
-      '1. O armazenamento de seus dados no servidor da empresa.'
-      '2. O registro de suas atividades para fins de auditoria.'
-      '3. ... (Demais cl'#225'usulas do termo)')
     ReadOnly = True
     ScrollBars = ssVertical
     TabOrder = 0
   end
-  object PanelBotoesTermos: TPanel
+  object PainelBotoesTermos: TPanel
     Left = 0
     Top = 350
     Width = 600
     Height = 50
     Align = alClient
     TabOrder = 1
-    object ButtonAceitar: TButton
+    object BotaoAceitar: TButton
       Left = 150
       Top = 10
       Width = 120
@@ -46,14 +39,16 @@ object ViewModalTermos: TViewModalTermos
       Caption = 'Aceitar'
       Default = True
       TabOrder = 0
+      OnClick = BotaoAceitarClick
     end
-    object ButtonRecusar: TButton
+    object BotaoRecusar: TButton
       Left = 330
       Top = 10
       Width = 120
       Height = 30
       Caption = 'Recusar'
       TabOrder = 1
+      OnClick = BotaoRecusarClick
     end
   end
 end

--- a/CRUDMaker/src/view/UViewModalTermos.pas
+++ b/CRUDMaker/src/view/UViewModalTermos.pas
@@ -1,4 +1,4 @@
-unit UViewModalTermos;
+﻿unit UViewModalTermos;
 
 interface
 
@@ -7,15 +7,23 @@ uses
   Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, Vcl.ExtCtrls;
 
 type
+  TOnAceitarTermosEvent = procedure of object;
+  TOnRecusarTermosEvent = procedure of object;
+
   TViewModalTermos = class(TForm)
     MemoTermos: TMemo;
-    PanelBotoesTermos: TPanel;
-    ButtonAceitar: TButton;
-    ButtonRecusar: TButton;
+    PainelBotoesTermos: TPanel;
+    BotaoAceitar: TButton;
+    BotaoRecusar: TButton;
+    procedure BotaoAceitarClick(Sender: TObject);
+    procedure BotaoRecusarClick(Sender: TObject);
+    procedure FormCreate(Sender: TObject);
   private
-    { Private declarations }
+    FOnAceitarTermos: TOnAceitarTermosEvent;
+    FOnRecusarTermos: TOnRecusarTermosEvent;
   public
-    { Public declarations }
+    property OnAceitarTermos: TOnAceitarTermosEvent read FOnAceitarTermos write FOnAceitarTermos;
+    property OnRecusarTermos: TOnRecusarTermosEvent read FOnRecusarTermos write FOnRecusarTermos;
   end;
 
 var
@@ -24,5 +32,30 @@ var
 implementation
 
 {$R *.dfm}
+
+procedure TViewModalTermos.FormCreate(Sender: TObject);
+begin
+  MemoTermos.Lines.Text :=
+    'TERMO DE RESPONSABILIDADE' + sLineBreak + sLineBreak +
+    'Ao utilizar este sistema em modo público, você concorda com:' + sLineBreak + sLineBreak +
+    '1. O armazenamento de seus dados no servidor da empresa.' + sLineBreak +
+    '2. O registro de suas atividades para fins de auditoria.' + sLineBreak +
+    '3. A responsabilidade pelo uso adequado dos recursos disponibilizados.' + sLineBreak +
+    '4. O cumprimento das políticas de segurança da informação da empresa.';
+end;
+
+procedure TViewModalTermos.BotaoAceitarClick(Sender: TObject);
+begin
+  if Assigned(FOnAceitarTermos) then
+    FOnAceitarTermos;
+  ModalResult := mrOk;
+end;
+
+procedure TViewModalTermos.BotaoRecusarClick(Sender: TObject);
+begin
+  if Assigned(FOnRecusarTermos) then
+    FOnRecusarTermos;
+  ModalResult := mrCancel;
+end;
 
 end.

--- a/CRUDMaker/src/view/UViewPrincipal.dfm
+++ b/CRUDMaker/src/view/UViewPrincipal.dfm
@@ -12,76 +12,66 @@ object ViewPrincipal: TViewPrincipal
   Font.Style = []
   Position = poScreenCenter
   TextHeight = 15
-  object PanelTop: TPanel
+  object PainelTopo: TPanel
     Left = 0
     Top = 0
     Width = 900
     Height = 60
     Align = alTop
-    TabOrder = 0
-    object LabelBemVindo: TLabel
+    TabOrder = 1
+    object RotuloBemVindo: TLabel
       Left = 10
       Top = 20
-      Width = 100
+      Width = 108
       Height = 15
       Caption = 'Bem-vindo, Usu'#225'rio!'
     end
-    object ButtonLogout: TButton
-      Left = 790
-      Top = 15
-      Width = 100
-      Height = 30
-      Caption = 'Sair'
-      TabOrder = 0
-    end
   end
-  object PageControlMain: TPageControl
+  object ControleAbasPrincipal: TPageControl
     Left = 0
     Top = 60
     Width = 900
     Height = 468
-    ActivePage = TabSheetPlanilhas
+    ActivePage = AbaPlanilhas
     Align = alClient
-    TabOrder = 1
-    object TabSheetPlanilhas: TTabSheet
+    TabOrder = 0
+    object AbaPlanilhas: TTabSheet
       Caption = 'Planilhas'
-      object Splitter1: TSplitter
+      object Divisor1: TSplitter
         Left = 200
         Top = 0
-        Height = 437
-        ExplicitLeft = 248
-        ExplicitTop = 88
-        ExplicitHeight = 100
+        Height = 438
+        ExplicitHeight = 437
       end
-      object PanelPlanilhasEsquerda: TPanel
+      object PainelEsquerdoPlanilhas: TPanel
         Left = 0
         Top = 0
         Width = 200
-        Height = 437
+        Height = 438
         Align = alLeft
         TabOrder = 0
-        object ListBoxPlanilhas: TListBox
+        object ListaPlanilhas: TListBox
           Left = 1
           Top = 1
           Width = 198
-          Height = 435
+          Height = 436
           Align = alClient
           ItemHeight = 15
           TabOrder = 0
         end
       end
-      object PanelPlanilhasDireita: TPanel
+      object PainelDireitoPlanilhas: TPanel
         Left = 203
         Top = 0
         Width = 689
-        Height = 437
+        Height = 438
         Align = alClient
         TabOrder = 1
-        object DBGridPlanilha: TDBGrid
+        object GradePlanilha: TDBGrid
           Left = 1
           Top = 1
           Width = 687
-          Height = 405
+          Height = 406
           Align = alClient
           TabOrder = 0
           TitleFont.Charset = DEFAULT_CHARSET
@@ -90,14 +80,14 @@ object ViewPrincipal: TViewPrincipal
           TitleFont.Name = 'Segoe UI'
           TitleFont.Style = []
         end
-        object PanelPlanilhaBotoes: TPanel
+        object PainelBotoesPlanilha: TPanel
           Left = 1
-          Top = 406
+          Top = 407
           Width = 687
           Height = 30
           Align = alBottom
           TabOrder = 1
-          object ButtonEditarPlanilha: TButton
+          object BotaoEditarPlanilha: TButton
             Left = 10
             Top = 2
             Width = 100
@@ -105,7 +95,7 @@ object ViewPrincipal: TViewPrincipal
             Caption = 'Editar'
             TabOrder = 0
           end
-          object ButtonExcluirPlanilha: TButton
+          object BotaoExcluirPlanilha: TButton
             Left = 120
             Top = 2
             Width = 100
@@ -113,7 +103,7 @@ object ViewPrincipal: TViewPrincipal
             Caption = 'Excluir'
             TabOrder = 1
           end
-          object ButtonNovoRelatorioPlanilha: TButton
+          object BotaoCriarRelatorioPlanilha: TButton
             Left = 230
             Top = 2
             Width = 150
@@ -124,25 +114,22 @@ object ViewPrincipal: TViewPrincipal
         end
       end
     end
-    object TabSheetRelatorios: TTabSheet
+    object AbaRelatorios: TTabSheet
       Caption = 'Relat'#243'rios'
       ImageIndex = 1
-      object Splitter2: TSplitter
+      object Divisor2: TSplitter
         Left = 200
         Top = 0
         Height = 437
-        ExplicitLeft = 280
-        ExplicitTop = 168
-        ExplicitHeight = 100
       end
-      object PanelRelatoriosEsquerda: TPanel
+      object PainelEsquerdoRelatorios: TPanel
         Left = 0
         Top = 0
         Width = 200
         Height = 437
         Align = alLeft
         TabOrder = 0
-        object ListBoxRelatorios: TListBox
+        object ListaRelatorios: TListBox
           Left = 1
           Top = 1
           Width = 198
@@ -152,13 +139,14 @@ object ViewPrincipal: TViewPrincipal
           TabOrder = 0
         end
       end
-      object PanelRelatoriosDireita: TPanel
+      object PainelDireitoRelatorios: TPanel
         Left = 203
         Top = 0
         Width = 689
-        Height = 437
+        Height = 438
         Align = alClient
         TabOrder = 1
+        ExplicitHeight = 437
         object MemoVisualizadorRelatorio: TMemo
           Left = 1
           Top = 1
@@ -168,14 +156,14 @@ object ViewPrincipal: TViewPrincipal
           ScrollBars = ssVertical
           TabOrder = 0
         end
-        object PanelRelatorioBotoes: TPanel
+        object PainelBotoesRelatorio: TPanel
           Left = 1
           Top = 406
           Width = 687
           Height = 30
           Align = alBottom
           TabOrder = 1
-          object ButtonEditarRelatorio: TButton
+          object BotaoEditarRelatorio: TButton
             Left = 10
             Top = 2
             Width = 100
@@ -183,7 +171,7 @@ object ViewPrincipal: TViewPrincipal
             Caption = 'Editar'
             TabOrder = 0
           end
-          object ButtonExcluirRelatorio: TButton
+          object BotaoExcluirRelatorio: TButton
             Left = 120
             Top = 2
             Width = 100
@@ -191,7 +179,7 @@ object ViewPrincipal: TViewPrincipal
             Caption = 'Excluir'
             TabOrder = 1
           end
-          object ButtonVisualizarRelatorio: TButton
+          object BotaoVisualizarRelatorio: TButton
             Left = 230
             Top = 2
             Width = 100
@@ -202,10 +190,10 @@ object ViewPrincipal: TViewPrincipal
         end
       end
     end
-    object TabSheetAssociacoes: TTabSheet
+    object AbaAssociacoes: TTabSheet
       Caption = 'Planilhas & Relat'#243'rios'
       ImageIndex = 2
-      object DBGridAssociacoes: TDBGrid
+      object GradeAssociacoes: TDBGrid
         Left = 0
         Top = 0
         Width = 892
@@ -220,12 +208,37 @@ object ViewPrincipal: TViewPrincipal
       end
     end
   end
-  object StatusBarPrincipal: TStatusBar
+  object BarraStatusPrincipal: TStatusBar
     Left = 0
     Top = 528
     Width = 900
     Height = 22
     Panels = <>
     SimplePanel = True
+  end
+  object MainMenuPrincipal: TMainMenu
+    Left = 24
+    Top = 16
+    object MenuItemArquivo: TMenuItem
+      Caption = '&Arquivo'
+      object MenuItemSair: TMenuItem
+        Caption = 'Sai&r'
+      end
+    end
+    object MenuItemFerramentas: TMenuItem
+      Caption = '&Ferramentas'
+      object MenuItemGerenciarDados: TMenuItem
+        Caption = '&Gerenciar Dados'
+      end
+      object MenuItemCompartilhar: TMenuItem
+        Caption = '&Compartilhar'
+      end
+    end
+    object MenuItemAjuda: TMenuItem
+      Caption = '&Ajuda'
+      object MenuItemSobre: TMenuItem
+        Caption = '&Sobre'
+      end
+    end
   end
 end

--- a/CRUDMaker/src/view/UViewPrincipal.pas
+++ b/CRUDMaker/src/view/UViewPrincipal.pas
@@ -1,45 +1,88 @@
-unit UViewPrincipal;
+﻿unit UViewPrincipal;
 
 interface
 
 uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
   Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.ComCtrls, Vcl.ExtCtrls, Vcl.Grids, Vcl.DBGrids,
-  Data.DB, Vcl.StdCtrls;
+  Data.DB, Vcl.StdCtrls, Vcl.Menus,
+  UPlanilhaDTO, URelatorioDTO;
 
 type
+  TNavegarParaEditorPlanilhaEvent = procedure(const APlanilha: TPlanilhaDTO) of object;
+  TNavegarParaNovoRelatorioComBaseEvent = procedure(const APlanilhaBase: TPlanilhaDTO) of object;
+  TNavegarParaEditorRelatorioEvent = procedure(const ARelatorio: TRelatorioDTO) of object;
+  TNavegarParaVisualizadorRelatorioEvent = procedure(const ARelatorio: TRelatorioDTO) of object;
+  TOnSolicitarLogoutEvent = procedure of object;
+  TOnAbrirGerenciadorEvent = procedure of object;
+  TOnAbrirCompartilhamentoEvent = procedure of object;
+
   TViewPrincipal = class(TForm)
-    PanelTop: TPanel;
-    LabelBemVindo: TLabel;
-    ButtonLogout: TButton;
-    PageControlMain: TPageControl;
-    TabSheetPlanilhas: TTabSheet;
-    Splitter1: TSplitter;
-    PanelPlanilhasEsquerda: TPanel;
-    ListBoxPlanilhas: TListBox;
-    PanelPlanilhasDireita: TPanel;
-    DBGridPlanilha: TDBGrid;
-    PanelPlanilhaBotoes: TPanel;
-    ButtonEditarPlanilha: TButton;
-    ButtonExcluirPlanilha: TButton;
-    ButtonNovoRelatorioPlanilha: TButton;
-    TabSheetRelatorios: TTabSheet;
-    Splitter2: TSplitter;
-    PanelRelatoriosEsquerda: TPanel;
-    ListBoxRelatorios: TListBox;
-    PanelRelatoriosDireita: TPanel;
+    MainMenuPrincipal: TMainMenu;
+    MenuItemArquivo: TMenuItem;
+    MenuItemSair: TMenuItem;
+    MenuItemFerramentas: TMenuItem;
+    MenuItemGerenciarDados: TMenuItem;
+    MenuItemCompartilhar: TMenuItem;
+    MenuItemAjuda: TMenuItem;
+    MenuItemSobre: TMenuItem;
+    PainelTopo: TPanel;
+    RotuloBemVindo: TLabel;
+    ControleAbasPrincipal: TPageControl;
+    AbaPlanilhas: TTabSheet;
+    Divisor1: TSplitter;
+    PainelEsquerdoPlanilhas: TPanel;
+    ListaPlanilhas: TListBox;
+    PainelDireitoPlanilhas: TPanel;
+    GradePlanilha: TDBGrid;
+    PainelBotoesPlanilha: TPanel;
+    BotaoEditarPlanilha: TButton;
+    BotaoExcluirPlanilha: TButton;
+    BotaoCriarRelatorioPlanilha: TButton;
+    AbaRelatorios: TTabSheet;
+    Divisor2: TSplitter;
+    PainelEsquerdoRelatorios: TPanel;
+    ListaRelatorios: TListBox;
+    PainelDireitoRelatorios: TPanel;
     MemoVisualizadorRelatorio: TMemo;
-    PanelRelatorioBotoes: TPanel;
-    ButtonEditarRelatorio: TButton;
-    ButtonExcluirRelatorio: TButton;
-    ButtonVisualizarRelatorio: TButton;
-    TabSheetAssociacoes: TTabSheet;
-    DBGridAssociacoes: TDBGrid;
-    StatusBarPrincipal: TStatusBar;
+    PainelBotoesRelatorio: TPanel;
+    BotaoEditarRelatorio: TButton;
+    BotaoExcluirRelatorio: TButton;
+    BotaoVisualizarRelatorio: TButton;
+    AbaAssociacoes: TTabSheet;
+    GradeAssociacoes: TDBGrid;
+    BarraStatusPrincipal: TStatusBar;
+    procedure MenuItemSairClick(Sender: TObject);
+    procedure MenuItemGerenciarDadosClick(Sender: TObject);
+    procedure MenuItemCompartilharClick(Sender: TObject);
+    procedure BotaoEditarPlanilhaClick(Sender: TObject);
+    procedure BotaoExcluirPlanilhaClick(Sender: TObject);
+    procedure BotaoCriarRelatorioPlanilhaClick(Sender: TObject);
+    procedure BotaoEditarRelatorioClick(Sender: TObject);
+    procedure BotaoExcluirRelatorioClick(Sender: TObject);
+    procedure BotaoVisualizarRelatorioClick(Sender: TObject);
+    procedure FormCreate(Sender: TObject);
   private
-    { Private declarations }
+    FPlanilhaSelecionada: TPlanilhaDTO;
+    FRelatorioSelecionado: TRelatorioDTO;
+    FOnNavegarParaEditorPlanilha: TNavegarParaEditorPlanilhaEvent;
+    FOnNavegarParaNovoRelatorioComBase: TNavegarParaNovoRelatorioComBaseEvent;
+    FOnNavegarParaEditorRelatorio: TNavegarParaEditorRelatorioEvent;
+    FOnNavegarParaVisualizadorRelatorio: TNavegarParaVisualizadorRelatorioEvent;
+    FOnSolicitarLogout: TOnSolicitarLogoutEvent;
+    FOnAbrirGerenciador: TOnAbrirGerenciadorEvent;
+    FOnAbrirCompartilhamento: TOnAbrirCompartilhamentoEvent;
+    procedure AtualizarExibicaoPlanilha;
+    procedure AtualizarExibicaoRelatorio;
   public
-    { Public declarations }
+    procedure DefinirNomeUsuario(const ANome: string);
+    property OnNavegarParaEditorPlanilha: TNavegarParaEditorPlanilhaEvent read FOnNavegarParaEditorPlanilha write FOnNavegarParaEditorPlanilha;
+    property OnNavegarParaNovoRelatorioComBase: TNavegarParaNovoRelatorioComBaseEvent read FOnNavegarParaNovoRelatorioComBase write FOnNavegarParaNovoRelatorioComBase;
+    property OnNavegarParaEditorRelatorio: TNavegarParaEditorRelatorioEvent read FOnNavegarParaEditorRelatorio write FOnNavegarParaEditorRelatorio;
+    property OnNavegarParaVisualizadorRelatorio: TNavegarParaVisualizadorRelatorioEvent read FOnNavegarParaVisualizadorRelatorio write FOnNavegarParaVisualizadorRelatorio;
+    property OnSolicitarLogout: TOnSolicitarLogoutEvent read FOnSolicitarLogout write FOnSolicitarLogout;
+    property OnAbrirGerenciador: TOnAbrirGerenciadorEvent read FOnAbrirGerenciador write FOnAbrirGerenciador;
+    property OnAbrirCompartilhamento: TOnAbrirCompartilhamentoEvent read FOnAbrirCompartilhamento write FOnAbrirCompartilhamento;
   end;
 
 var
@@ -48,5 +91,99 @@ var
 implementation
 
 {$R *.dfm}
+
+uses System.UITypes;
+
+procedure TViewPrincipal.FormCreate(Sender: TObject);
+begin
+  ControleAbasPrincipal.ActivePageIndex := 0;
+end;
+
+procedure TViewPrincipal.DefinirNomeUsuario(const ANome: string);
+begin
+  RotuloBemVindo.Caption := 'Bem-vindo, ' + ANome + '!';
+end;
+
+procedure TViewPrincipal.MenuItemSairClick(Sender: TObject);
+begin
+  if Assigned(FOnSolicitarLogout) then
+    FOnSolicitarLogout;
+end;
+
+procedure TViewPrincipal.MenuItemGerenciarDadosClick(Sender: TObject);
+begin
+  if Assigned(FOnAbrirGerenciador) then
+    FOnAbrirGerenciador;
+end;
+
+procedure TViewPrincipal.MenuItemCompartilharClick(Sender: TObject);
+begin
+   if Assigned(FOnAbrirCompartilhamento) then
+    FOnAbrirCompartilhamento;
+end;
+
+procedure TViewPrincipal.BotaoEditarPlanilhaClick(Sender: TObject);
+begin
+  if Assigned(FOnNavegarParaEditorPlanilha) then
+    FOnNavegarParaEditorPlanilha(FPlanilhaSelecionada);
+end;
+
+procedure TViewPrincipal.BotaoExcluirPlanilhaClick(Sender: TObject);
+begin
+  if Assigned(FPlanilhaSelecionada) then
+  begin
+    if MessageDlg('Tem certeza que deseja excluir a planilha "' + FPlanilhaSelecionada.Titulo + '"?',
+      mtConfirmation, [mbYes, mbNo], 0) = mrYes then
+    begin
+      // TODO: Chamar serviço para excluir a planilha
+    end;
+  end;
+end;
+
+procedure TViewPrincipal.BotaoCriarRelatorioPlanilhaClick(Sender: TObject);
+begin
+  if Assigned(FPlanilhaSelecionada) then
+  begin
+     if Assigned(FOnNavegarParaNovoRelatorioComBase) then
+       FOnNavegarParaNovoRelatorioComBase(FPlanilhaSelecionada);
+  end;
+end;
+
+procedure TViewPrincipal.BotaoEditarRelatorioClick(Sender: TObject);
+begin
+  if Assigned(FOnNavegarParaEditorRelatorio) then
+    FOnNavegarParaEditorRelatorio(FRelatorioSelecionado);
+end;
+
+procedure TViewPrincipal.BotaoExcluirRelatorioClick(Sender: TObject);
+begin
+  if Assigned(FRelatorioSelecionado) then
+  begin
+    if MessageDlg('Tem certeza que deseja excluir o relatório "' + FRelatorioSelecionado.Titulo + '"?',
+      mtConfirmation, [mbYes, mbNo], 0) = mrYes then
+    begin
+      // TODO: Chamar serviço para excluir o relatório
+    end;
+  end;
+end;
+
+procedure TViewPrincipal.BotaoVisualizarRelatorioClick(Sender: TObject);
+begin
+  if Assigned(FRelatorioSelecionado) then
+  begin
+     if Assigned(FOnNavegarParaVisualizadorRelatorio) then
+       FOnNavegarParaVisualizadorRelatorio(FRelatorioSelecionado);
+  end;
+end;
+
+procedure TViewPrincipal.AtualizarExibicaoPlanilha;
+begin
+  // Lógica para atualizar GradePlanilha com base na seleção em ListaPlanilhas
+end;
+
+procedure TViewPrincipal.AtualizarExibicaoRelatorio;
+begin
+  // Lógica para atualizar MemoVisualizadorRelatorio com base na seleção em ListaRelatorios
+end;
 
 end.

--- a/CRUDMaker/src/view/UViewVisualizadorRelatorio.dfm
+++ b/CRUDMaker/src/view/UViewVisualizadorRelatorio.dfm
@@ -12,21 +12,21 @@ object ViewVisualizadorRelatorio: TViewVisualizadorRelatorio
   Font.Style = []
   Position = poScreenCenter
   TextHeight = 15
-  object PanelVisualizadorTop: TPanel
+  object PainelVisualizadorTopo: TPanel
     Left = 0
     Top = 0
     Width = 800
     Height = 50
     Align = alTop
     TabOrder = 0
-    object LabelNomeRelatorio: TLabel
+    object RotuloNomeRelatorio: TLabel
       Left = 10
       Top = 15
       Width = 100
       Height = 15
       Caption = 'Nome do Relat'#243'rio'
     end
-    object ButtonImprimir: TButton
+    object BotaoImprimir: TButton
       Left = 690
       Top = 10
       Width = 100
@@ -35,7 +35,7 @@ object ViewVisualizadorRelatorio: TViewVisualizadorRelatorio
       TabOrder = 0
     end
   end
-  object RichEditVisualizador: TRichEdit
+  object EditorVisualizador: TRichEdit
     Left = 0
     Top = 50
     Width = 800
@@ -50,14 +50,14 @@ object ViewVisualizadorRelatorio: TViewVisualizadorRelatorio
     ScrollBars = ssVertical
     TabOrder = 1
   end
-  object PanelVisualizadorBottom: TPanel
+  object PainelVisualizadorRodape: TPanel
     Left = 0
     Top = 478
     Width = 800
     Height = 22
     Align = alBottom
     TabOrder = 2
-    object StatusBarVisualizador: TStatusBar
+    object BarraStatusVisualizador: TStatusBar
       Left = 1
       Top = 1
       Width = 798

--- a/CRUDMaker/src/view/UViewVisualizadorRelatorio.pas
+++ b/CRUDMaker/src/view/UViewVisualizadorRelatorio.pas
@@ -1,23 +1,28 @@
-unit UViewVisualizadorRelatorio;
+﻿unit UViewVisualizadorRelatorio;
 
 interface
 
 uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
-  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.ComCtrls, Vcl.StdCtrls, Vcl.ExtCtrls;
+  Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.ComCtrls, Vcl.StdCtrls, Vcl.ExtCtrls,
+  URelatorioDTO;
 
 type
   TViewVisualizadorRelatorio = class(TForm)
-    PanelVisualizadorTop: TPanel;
-    LabelNomeRelatorio: TLabel;
-    ButtonImprimir: TButton;
-    RichEditVisualizador: TRichEdit;
-    PanelVisualizadorBottom: TPanel;
-    StatusBarVisualizador: TStatusBar;
+    PainelVisualizadorTopo: TPanel;
+    RotuloNomeRelatorio: TLabel;
+    BotaoImprimir: TButton;
+    EditorVisualizador: TRichEdit;
+    PainelVisualizadorRodape: TPanel;
+    BarraStatusVisualizador: TStatusBar;
+    procedure BotaoImprimirClick(Sender: TObject);
+    procedure FormCreate(Sender: TObject);
   private
-    { Private declarations }
+    FRelatorio: TRelatorioDTO;
+    procedure ExibirRelatorioNaInterface;
   public
-    { Public declarations }
+    constructor Create(AOwner: TComponent; ARelatorio: TRelatorioDTO); reintroduce;
+    destructor Destroy; override;
   end;
 
 var
@@ -26,5 +31,38 @@ var
 implementation
 
 {$R *.dfm}
+
+constructor TViewVisualizadorRelatorio.Create(AOwner: TComponent; ARelatorio: TRelatorioDTO);
+begin
+  inherited Create(AOwner);
+  FRelatorio := ARelatorio;
+end;
+
+destructor TViewVisualizadorRelatorio.Destroy;
+begin
+  inherited;
+end;
+
+procedure TViewVisualizadorRelatorio.FormCreate(Sender: TObject);
+begin
+  if Assigned(FRelatorio) then
+  begin
+    ExibirRelatorioNaInterface;
+  end;
+end;
+
+procedure TViewVisualizadorRelatorio.ExibirRelatorioNaInterface;
+begin
+  if Assigned(FRelatorio) then
+  begin
+    RotuloNomeRelatorio.Caption := FRelatorio.Titulo;
+    EditorVisualizador.Lines.Text := 'Conteúdo do relatório: ' + FRelatorio.Conteudo;
+  end;
+end;
+
+procedure TViewVisualizadorRelatorio.BotaoImprimirClick(Sender: TObject);
+begin
+  ShowMessage('Funcionalidade de impressão acionada.');
+end;
 
 end.


### PR DESCRIPTION
- Adiciona controllers de eventos nas views principais para comunicação com o controller
- Implementa navegação entre UViewPrincipal e views filhas (editor, visualizador, gerenciador, compartilhamento)
- Configura eventos de clique para botões de ação em todas as views
- Adiciona mecanismo de status de termos de uso no controller
- Conecta UViewLogin com exibição de termos para modo público
- Implementa fluxo de aceite/recusa de termos com atualização de status no controller
- Views agora utilizam eventos para notificar o controller sobre ações do usuário
- Controller centraliza a lógica de navegação e gerenciamento de estado da aplicação
- Atualiza construtores de views que requerem parâmetros (ex: VisualizadorRelatorio)
- Corrige incompatibilidades de tipos no controller relacionadas a ModalResult
- Remove dependências cíclicas entre views e controller através de eventos